### PR TITLE
Front End Admin Home Page and navbars

### DIFF
--- a/team-utilisation-monitor/libs/client/admin/feature/src/lib/admin-home-page/admin-home-page.component.html
+++ b/team-utilisation-monitor/libs/client/admin/feature/src/lib/admin-home-page/admin-home-page.component.html
@@ -17,9 +17,8 @@
                             <hr>
                             <mat-grid-list cols="2">
                                 <mat-grid-tile><mat-icon>account_box</mat-icon></mat-grid-tile>
-                                <mat-grid-tile><h1>109</h1></mat-grid-tile>
+                                <mat-grid-tile><h1>{{nrOfEmployees}}</h1></mat-grid-tile>
                             </mat-grid-list>
-                            
                         </mat-card-content>
                     </mat-card>
                 </mat-grid-tile>
@@ -30,7 +29,7 @@
                            <hr>
                            <mat-grid-list cols="2">
                                 <mat-grid-tile><mat-icon>rocket_launch</mat-icon></mat-grid-tile>
-                                <mat-grid-tile><h1>82%</h1></mat-grid-tile>
+                                <mat-grid-tile><h1>{{utilizationPersentage}}%</h1></mat-grid-tile>
                             </mat-grid-list>
                         </mat-card-content>
                     </mat-card>
@@ -42,7 +41,7 @@
                             <hr>
                             <mat-grid-list cols="2">
                                 <mat-grid-tile><mat-icon>done_all</mat-icon></mat-grid-tile>
-                                <mat-grid-tile><h1>43/99</h1></mat-grid-tile>
+                                <mat-grid-tile><h1>{{nrOfOpenProjects}}/{{nrOfClosedProjects}}</h1></mat-grid-tile>
                             </mat-grid-list>
                          </mat-card-content>
                     </mat-card>
@@ -54,7 +53,7 @@
                             <hr>
                             <mat-grid-list cols="2">
                                 <mat-grid-tile><mat-icon>supervisor_account</mat-icon></mat-grid-tile>
-                                <mat-grid-tile><h1>22</h1></mat-grid-tile>
+                                <mat-grid-tile><h1>{{nrOfTeams}}</h1></mat-grid-tile>
                             </mat-grid-list>
                         </mat-card-content>
                     </mat-card>

--- a/team-utilisation-monitor/libs/client/admin/feature/src/lib/admin-home-page/admin-home-page.component.html
+++ b/team-utilisation-monitor/libs/client/admin/feature/src/lib/admin-home-page/admin-home-page.component.html
@@ -11,27 +11,57 @@
             <mat-grid-list cols="4" rowHeight="2:1">
                 <mat-grid-tile>
                     <mat-card>
-                        <mat-card-content>Card that will display Nr of active Emplyees</mat-card-content>
+                        <mat-card-title># of Emplyees</mat-card-title>
+
+                        <mat-card-content>
+                            <hr>
+                            <mat-grid-list cols="2">
+                                <mat-grid-tile><mat-icon>account_box</mat-icon></mat-grid-tile>
+                                <mat-grid-tile><h1>109</h1></mat-grid-tile>
+                            </mat-grid-list>
+                            
+                        </mat-card-content>
                     </mat-card>
                 </mat-grid-tile>
                 <mat-grid-tile>
                     <mat-card>
-                        <mat-card-content>Card that will display % utilization of the company</mat-card-content>
+                        <mat-card-title>Utilization</mat-card-title>
+                        <mat-card-content>
+                           <hr>
+                           <mat-grid-list cols="2">
+                                <mat-grid-tile><mat-icon>rocket_launch</mat-icon></mat-grid-tile>
+                                <mat-grid-tile><h1>82%</h1></mat-grid-tile>
+                            </mat-grid-list>
+                        </mat-card-content>
                     </mat-card>
                 </mat-grid-tile>
                 <mat-grid-tile>
                     <mat-card>
-                        <mat-card-content>Card that will display Nr of open and completed projects</mat-card-content>
+                        <mat-card-title>Open Projects</mat-card-title>
+                        <mat-card-content>
+                            <hr>
+                            <mat-grid-list cols="2">
+                                <mat-grid-tile><mat-icon>done_all</mat-icon></mat-grid-tile>
+                                <mat-grid-tile><h1>43/99</h1></mat-grid-tile>
+                            </mat-grid-list>
+                         </mat-card-content>
                     </mat-card>
                 </mat-grid-tile>
                 <mat-grid-tile>
                     <mat-card>
-                        <mat-card-content>Card that will display Nr of teams</mat-card-content>
+                        <mat-card-title># of Teams</mat-card-title>
+                        <mat-card-content>
+                            <hr>
+                            <mat-grid-list cols="2">
+                                <mat-grid-tile><mat-icon>supervisor_account</mat-icon></mat-grid-tile>
+                                <mat-grid-tile><h1>22</h1></mat-grid-tile>
+                            </mat-grid-list>
+                        </mat-card-content>
                     </mat-card>
                 </mat-grid-tile>
                 <mat-grid-tile colspan="4" rowspan="3">
                     <mat-card class="graphCard">
-                        <mat-card-content >Graph of company utilization over time</mat-card-content>
+                        <mat-card-footer>Graph of company utilization over time</mat-card-footer>
                     </mat-card>
                 </mat-grid-tile>
             </mat-grid-list>

--- a/team-utilisation-monitor/libs/client/admin/feature/src/lib/admin-home-page/admin-home-page.component.scss
+++ b/team-utilisation-monitor/libs/client/admin/feature/src/lib/admin-home-page/admin-home-page.component.scss
@@ -32,3 +32,18 @@ mat-card{
 mat-sidenav-content{
 	background-color: rgb(228, 228, 228);
 }
+
+img{
+	height: 80px;
+	margin-bottom: 30px;
+}
+
+mat-icon{
+	margin-bottom: 50px;
+	transform: scale(3);
+  }
+
+h1{
+	margin-bottom: 50px;
+	transform: scale(1.3);
+}

--- a/team-utilisation-monitor/libs/client/admin/feature/src/lib/admin-home-page/admin-home-page.component.ts
+++ b/team-utilisation-monitor/libs/client/admin/feature/src/lib/admin-home-page/admin-home-page.component.ts
@@ -7,8 +7,14 @@ import { Component, OnInit } from '@angular/core';
 })
 export class AdminHomePageComponent implements OnInit {
   //constructor() {}
-  boolshow = true;
 
+  //information cards values, calculate them and update the variables to link it to the front end
+  boolshow = true;
+  nrOfEmployees = 108;
+  utilizationPersentage = 80;
+  nrOfOpenProjects = 40;
+  nrOfClosedProjects = 50;
+  nrOfTeams = 20;
 
   ngOnInit(): void {
     console.log();

--- a/team-utilisation-monitor/libs/client/admin/feature/src/lib/client-admin-feature.module.ts
+++ b/team-utilisation-monitor/libs/client/admin/feature/src/lib/client-admin-feature.module.ts
@@ -26,6 +26,7 @@ import { CompEmployeeIndividualComponent } from './comp-employee-individual/comp
 import { CompNavbarComponent } from './comp-navbar/comp-navbar.component';
 import { CompAdminTopnavComponent } from './comp-admin-topnav/comp-admin-topnav.component';
 import { MatExpansionModule } from '@angular/material/expansion';
+import { MatBadgeModule } from '@angular/material/badge';
 
 @NgModule({
   imports: [
@@ -52,6 +53,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
     MatSidenavModule,
     MatProgressBarModule,
     MatExpansionModule,
+    MatBadgeModule,
     RouterModule.forChild([]),
   ],
 

--- a/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-admin-topnav/comp-admin-topnav.component.html
+++ b/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-admin-topnav/comp-admin-topnav.component.html
@@ -3,7 +3,7 @@
         <mat-icon>subject</mat-icon>
     </button>
 
-    <span id="adHome-CompanyName">University of Pretoria</span>
+    <span id="adHome-CompanyName">{{companyName}}</span>
     <span class="example-spacer"></span>
 
     <button routerLink="" mat-raised-button color="accent">Sign Out</button>

--- a/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-admin-topnav/comp-admin-topnav.component.ts
+++ b/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-admin-topnav/comp-admin-topnav.component.ts
@@ -6,6 +6,9 @@ import { Component, OnInit ,Input,Output,EventEmitter } from '@angular/core';
   styleUrls: ['./comp-admin-topnav.component.scss'],
 })
 export class CompAdminTopnavComponent implements OnInit {
+  companyName = "University of Pretoria";
+
+  //code to implement side nav toggeling below
   constructor() {
     this.state = true;
   }

--- a/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-navbar/comp-navbar.component.html
+++ b/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-navbar/comp-navbar.component.html
@@ -7,3 +7,13 @@
 <button class="SideNavButton" routerLink="/AdminListView" mat-button><mat-icon>assignment_ind</mat-icon>List View</button>
 <button class="SideNavButton" routerLink="/AdminCompanyView" mat-button><mat-icon>assessment</mat-icon>Company View</button>
 
+<mat-accordion>
+    <mat-expansion-panel (opened)="requestOpenState = true" (closed)="requestOpenState = false" expanded>
+        <mat-expansion-panel-header>
+            <mat-panel-title>
+                Requested Users
+            </mat-panel-title>
+        </mat-expansion-panel-header>
+        <button class="userRequestButton" mat-button>Add User <span class="example-spacer"></span><mat-icon>add</mat-icon></button>
+    </mat-expansion-panel>
+</mat-accordion>

--- a/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-navbar/comp-navbar.component.html
+++ b/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-navbar/comp-navbar.component.html
@@ -3,15 +3,17 @@
     <span class="example-spacer"></span>
 </mat-toolbar>
 
-<button class="SideNavButton" routerLink="/AdminHome" mat-button><mat-icon>home</mat-icon>Home Page</button>
-<button class="SideNavButton" routerLink="/AdminListView" mat-button><mat-icon>assignment_ind</mat-icon>List View</button>
-<button class="SideNavButton" routerLink="/AdminCompanyView" mat-button><mat-icon>assessment</mat-icon>Company View</button>
+<mat-card>
+    <button class="SideNavButton" routerLink="/AdminHome" mat-button><mat-icon>home</mat-icon>Home Page</button>
+    <button class="SideNavButton" routerLink="/AdminListView" mat-button><mat-icon>assignment_ind</mat-icon>List View</button>
+    <button class="SideNavButton" routerLink="/AdminCompanyView" mat-button><mat-icon>assessment</mat-icon>Company View</button>    
+</mat-card>
 
 <mat-accordion>
     <mat-expansion-panel (opened)="requestOpenState = true" (closed)="requestOpenState = false" expanded>
         <mat-expansion-panel-header>
             <mat-panel-title>
-                Requested Users
+                <p><span matBadge="9" matBadgeOverlap="false" matBadgeColor="accent">Requested Users</span></p>
             </mat-panel-title>
         </mat-expansion-panel-header>
         <button class="userRequestButton" mat-button>Add User <span class="example-spacer"></span><mat-icon>add</mat-icon></button>

--- a/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-navbar/comp-navbar.component.html
+++ b/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-navbar/comp-navbar.component.html
@@ -1,8 +1,9 @@
 <mat-toolbar color="primary" id="adHome-UserName">
-    Agape Mamphasa
+    {{adminName}}
     <span class="example-spacer"></span>
-    <!-- close navbar icon -->
 </mat-toolbar>
+
 <button class="SideNavButton" routerLink="/AdminHome" mat-button><mat-icon>home</mat-icon>Home Page</button>
 <button class="SideNavButton" routerLink="/AdminListView" mat-button><mat-icon>assignment_ind</mat-icon>List View</button>
 <button class="SideNavButton" routerLink="/AdminCompanyView" mat-button><mat-icon>assessment</mat-icon>Company View</button>
+

--- a/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-navbar/comp-navbar.component.scss
+++ b/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-navbar/comp-navbar.component.scss
@@ -15,3 +15,7 @@ mat-icon{
 	margin-top: 1px;
   transform: scale(1.3);
 }
+
+.userRequestButton{
+  width: 100%;
+}

--- a/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-navbar/comp-navbar.component.scss
+++ b/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-navbar/comp-navbar.component.scss
@@ -11,6 +11,7 @@
 }
 
 mat-icon{
-  margin: 5px;
+  margin: 7px;
 	margin-top: 1px;
+  transform: scale(1.3);
 }

--- a/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-navbar/comp-navbar.component.scss
+++ b/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-navbar/comp-navbar.component.scss
@@ -19,3 +19,12 @@ mat-icon{
 .userRequestButton{
   width: 100%;
 }
+
+mat-panel-title{
+  height: 50px;
+  margin-top: 15px;
+}
+
+mat-expansion-panel{
+  margin-top: 10px;
+}

--- a/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-navbar/comp-navbar.component.ts
+++ b/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-navbar/comp-navbar.component.ts
@@ -7,7 +7,9 @@ import { Component, OnInit } from '@angular/core';
 })
 export class CompNavbarComponent implements OnInit {
   //constructor() {} 
-  
+  adminName = "Agape Mamphasa";
+
+
   ngOnInit(): void {
     console.log()
   }

--- a/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-navbar/comp-navbar.component.ts
+++ b/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-navbar/comp-navbar.component.ts
@@ -8,7 +8,7 @@ import { Component, OnInit } from '@angular/core';
 export class CompNavbarComponent implements OnInit {
   //constructor() {} 
   adminName = "Agape Mamphasa";
-
+  requestOpenState = true;
 
   ngOnInit(): void {
     console.log()


### PR DESCRIPTION
Added google Icons to Admin Home Page
- Added Mat icons and not images as per Chris's request
- added better positioning and scaling of numbers and icons on stats bars

Added links to Information Cards, Admin Home Page
- Added links to information cards values, to be calculated
- Added Variables to the TS file that is linked to the front end

Side/Top Nav backend link
- Added link to ts file for adminName in Navbar
- Added link to ts file for companyName in TopNav

Added Requested users drop down to SideNav
- Added Requested users drop down to sidenav
- Added a "Add User" button to the dropdown

Admin SideNav added Badge to panel Title
- Added indicator badge to requested users
- this indicated the number of request pending by users