### PR TITLE
 Hotfix: moved team name to another backend linking

### DIFF
--- a/team-utilisation-monitor/libs/client/admin/feature/src/lib/admin-team-project-view/admin-team-project-view.component.html
+++ b/team-utilisation-monitor/libs/client/admin/feature/src/lib/admin-team-project-view/admin-team-project-view.component.html
@@ -22,8 +22,8 @@
                         Projects
                 </mat-panel-title></mat-expansion-panel-header>
                 <team-utilisation-monitor-comp-project-list
-                *ngFor="let project of OutProjectName"
-                [ProjectName] = "project"></team-utilisation-monitor-comp-project-list>
+                *ngFor="let project of OutProject"
+                [Project] = "project"></team-utilisation-monitor-comp-project-list>
             </mat-expansion-panel>
         </mat-accordion>
     </mat-sidenav-content>

--- a/team-utilisation-monitor/libs/client/admin/feature/src/lib/admin-team-project-view/admin-team-project-view.component.ts
+++ b/team-utilisation-monitor/libs/client/admin/feature/src/lib/admin-team-project-view/admin-team-project-view.component.ts
@@ -16,11 +16,11 @@ export class AdminTeamProjectViewComponent implements OnInit {
                   {Name: "Tuks Sport"},
                 ];
 
-  OutProjectName = [{Name: "Delete Software"},
-                    {Name: "Create Software"},
-                    {Name: "Create FronteEnd"},
-                    {Name: "Delete FronteEnd"},
-                    {Name: "Finish all Projects"},
+  OutProject = [{Name: "Delete Software", TeamName: "I Create Software"},
+                    {Name: "Create Software", TeamName: "I Create Software"},
+                    {Name: "Create FronteEnd", TeamName: "I Create Software"},
+                    {Name: "Delete FronteEnd", TeamName: "I Create Software"},
+                    {Name: "Finish all Projects", TeamName: "I Create Software"},
                   ];
 
   ngOnInit(): void {

--- a/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-project-list/comp-project-list.component.html
+++ b/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-project-list/comp-project-list.component.html
@@ -1,9 +1,9 @@
 <mat-card-content>
     <mat-card class="Mat-Individual">
         <mat-card-content class="InvdividualBox">
-                <span class="InvdividualName">{{ProjectName.Name}}</span>
+                <span class="InvdividualName">{{Project.Name}}</span>
                 <span class="example-spacer"></span>
-                <span class="InvdividualName">Team : {{TeamName}}</span>
+                <span class="InvdividualName">Team : {{Project.TeamName}}</span>
                 <span class="example-spacer"></span>
                 <button mat-raised-button class="CheckMarkButton" color="primary">
                     <mat-icon>done</mat-icon>

--- a/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-project-list/comp-project-list.component.ts
+++ b/team-utilisation-monitor/libs/client/admin/feature/src/lib/comp-project-list/comp-project-list.component.ts
@@ -7,7 +7,7 @@ import { Component, OnInit, Input } from '@angular/core';
 })
 export class CompProjectListComponent implements OnInit {
   //constructor() {}
-  @Input() ProjectName!: { Name: string };
+  @Input() Project!: { Name: string, TeamName: string };
 
   //get Team associated with the Project from back end;
   TeamName = "I Create Software";


### PR DESCRIPTION
- moved the position where you retrieve the team name form comp project list to admin team project. ts